### PR TITLE
Rebase mltests 

### DIFF
--- a/deploy/mltests.py
+++ b/deploy/mltests.py
@@ -188,6 +188,8 @@ def model_test(model, batch_x, batch_y, optim_fn,
                 check_nan(name, params)
             if test_infinite:
                 check_infinite(name, params)
+        
+        print(f"Epoch {epoch}: All tests passed successfully.")
             
             
 

--- a/mltests/__init__.py
+++ b/mltests/__init__.py
@@ -1,1 +1,0 @@
-from .mltests import get_params, check_gradient_smaller, check_greater, check_infinite, check_nan, check_smaller, model_test 


### PR DESCRIPTION
## Changes made in the PR:

This PR addresses issue #47. 

Earlier, mltests was implemented as a separate package within the deploy module. So in order to import it, you had to run the following command:

```py
import mltests 
```
Moving the mltests to deploy package will now allow the user to import the tests like this:
```py
import deploy.mltests
```
or simply
```py
import deploy
``` 
This will keep all the implementations under a single package, thus eliminating any ambiguity or confusion with any other Python module on PyPI.