### PR TITLE
add requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fire==0.4.0
 six==1.15.0
 termcolor==1.1.0
 flask
+requests


### PR DESCRIPTION
`requests` has been used in `apitests.py`. Due to this, the library was breaking after installation. I have added it to `requirements.txt` and now it is not breaking.